### PR TITLE
🧪 [Testing] Add tests for cardio history filtering

### DIFF
--- a/lib/workout/history.test.ts
+++ b/lib/workout/history.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import { strict as assert } from 'node:assert';
+import { isCardioHistoryItem, removeCardioHistoryEntries } from './history.js';
+
+test('isCardioHistoryItem: identifies Cardio entries', () => {
+  const cardioEntry = { type: { name: 'Cardio' } };
+  assert.equal(isCardioHistoryItem(cardioEntry), true);
+});
+
+test('isCardioHistoryItem: returns false for non-Cardio entries', () => {
+  const strengthEntry = { type: { name: 'Strength' } };
+  assert.equal(isCardioHistoryItem(strengthEntry), false);
+});
+
+test('isCardioHistoryItem: returns false gracefully for malformed entries', () => {
+  assert.equal(isCardioHistoryItem({}), false);
+  assert.equal(isCardioHistoryItem({ type: {} }), false);
+  assert.equal(isCardioHistoryItem({ type: null }), false);
+  assert.equal(isCardioHistoryItem(null as any), false);
+  assert.equal(isCardioHistoryItem(undefined as any), false);
+});
+
+test('removeCardioHistoryEntries: removes cardio entries and marks changed', () => {
+  const data = {
+    history: [
+      { id: 1, type: { name: 'Cardio' } },
+      { id: 2, type: { name: 'Strength' } },
+      { id: 3, type: { name: 'Cardio' } }
+    ],
+    otherProp: 'keep me'
+  };
+
+  const result = removeCardioHistoryEntries(data);
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.data.history, [
+    { id: 2, type: { name: 'Strength' } }
+  ]);
+  assert.equal(result.data.otherProp, 'keep me');
+});
+
+test('removeCardioHistoryEntries: does not change array if no cardio entries', () => {
+  const data = {
+    history: [
+      { id: 1, type: { name: 'Strength' } },
+      { id: 2, type: { name: 'Flexibility' } }
+    ],
+    otherProp: 'keep me'
+  };
+
+  const result = removeCardioHistoryEntries(data);
+
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.data.history, data.history);
+  assert.equal(result.data.otherProp, 'keep me');
+});
+
+test('removeCardioHistoryEntries: handles empty history', () => {
+  const data = {
+    history: []
+  };
+
+  const result = removeCardioHistoryEntries(data);
+
+  assert.equal(result.changed, false);
+  assert.deepEqual(result.data.history, []);
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `lib/workout/history.ts` lacked tests for its pure data filtering functions `isCardioHistoryItem` and `removeCardioHistoryEntries`.
📊 **Coverage:** Scenarios now tested include correctly identifying Cardio entries vs other types, gracefully handling malformed entries or null/empty cases, ensuring cardio entries are removed, non-cardio entries are kept, the `changed` boolean is set correctly, and generic properties in the data structure are maintained.
✨ **Result:** Test coverage improved with a deterministic node:test file verifying all boundary cases of history filtering.

---
*PR created automatically by Jules for task [7557321179052582290](https://jules.google.com/task/7557321179052582290) started by @sterenbergN*