### PR TITLE
🔒 Fix Path Traversal in `/api/download-album`

### DIFF
--- a/app/api/download-album/route.ts
+++ b/app/api/download-album/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: Request) {
 
     if (photoSrc) {
       const absolutePath = resolvePublicPath(photoSrc);
-      if (!absolutePath) {
+      if (!absolutePath || !absolutePath.startsWith(baseDir + path.sep)) {
         return NextResponse.json({ success: false, message: 'Invalid photo path' }, { status: 400 });
       }
       const filename = path.basename(absolutePath);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an insufficient path sanitization issue allowing access to any file inside the `public/` directory via the `photo` query parameter in the `download-album` API endpoint.
⚠️ **Risk:** The potential impact if left unfixed includes disclosure of any sensitive file or configuration residing in the `public/` directory, exposing it to potential attackers or authenticated users making illegitimate requests.
🛡️ **Solution:** The fix adds a direct prefix match validation `!absolutePath.startsWith(baseDir + path.sep)` to ensure that any requested file is strictly located inside the `public/uploads/` directory, which is correctly represented by `baseDir`.

---
*PR created automatically by Jules for task [14398306525630244560](https://jules.google.com/task/14398306525630244560) started by @sterenbergN*